### PR TITLE
Make TIMEOUTVALUE macro configurable via compiler flags

### DIFF
--- a/mcp_can_dfs.h
+++ b/mcp_can_dfs.h
@@ -44,7 +44,10 @@
 /*
  *   Begin mt
  */
+#ifndef TIMEOUTVALUE
 #define TIMEOUTVALUE    2500                                           /* In Microseconds, May need changed depending on application and baud rate */
+#endif
+
 #define MCP_SIDH        0
 #define MCP_SIDL        1
 #define MCP_EID8        2


### PR DESCRIPTION
The TIMEOUTVALUE macro currently has a hardcoded value of 2500 (microseconds), which limits the ability to use the library at lower CAN bus speeds (e.g. 10 kbps). At such speeds, a single CAN frame can take longer than 2.5 ms to transmit, causing `sendMsgBufBlocking()` to timeout even under normal conditions.

This commit wraps the TIMEOUTVALUE definition in a conditional `#ifndef`, allowing users to override it via compiler flags (`-DTIMEOUTVALUE=20000`) or a preceding `#define TIMEOUTVALUE` in their own project code before including `<mcp_can.h>`.

This change maintains full backward compatibility while enabling more flexible usage across diverse CAN configurations.

Example override in PlatformIO:

    build_flags = -DTIMEOUTVALUE=20000

Recommended for projects using slow CAN speeds, high bus load, or long arbitration delays.